### PR TITLE
configures Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "yarn"
+    directory: "/"
+    labels:
+      - "dependencies"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    vendor: true
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
- enforces `yarn` as package manager
- points to root directory for `package.json`
- labels package version updates as "dependencies"
- targets "main" branch
- "vendor" dependencies while updating

Signed-off-by: Dylan Archer <117687494+darcher-figo@users.noreply.github.com>